### PR TITLE
Update for Minecraft 1.21.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.11-SNAPSHOT'
+    id 'fabric-loom' version '1.13-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ version = "${project.mod_version}+${project.minecraft_version}"
 group = project.maven_group
 
 repositories {
+    maven { url "https://maven.fabricmc.net/" }
     maven { url "https://maven.terraformersmc.com/releases/" }
     maven { url "https://maven.shedaniel.me/" }
     maven { url "https://server.bbkr.space/artifactory/libs-release" }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,14 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
+# Disable unpick until Loom supports the metadata version bundled with 1.21.10 mappings.
+loom.unpick.enabled=false
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.9
-yarn_mappings=1.21.9+build.1
-loader_version=0.17.2
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.1
+loader_version=0.17.3
 
 # Mod Properties
 mod_version=1.9.2
@@ -14,7 +16,7 @@ maven_group=com.github.charlyb01
 archives_base_name=music_control
 
 # Dependencies
-fabric_version=0.134.0+1.21.9
+fabric_version=0.138.3+1.21.10
 modmenu_version=16.0.0-rc.1
-clothconfig_version=20.0.148
+clothconfig_version=20.0.149
 libgui_version=15.0.0+1.21.9-rc1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'

--- a/src/main/java/com/github/charlyb01/music_control/client/MusicKeyBinding.java
+++ b/src/main/java/com/github/charlyb01/music_control/client/MusicKeyBinding.java
@@ -1,10 +1,10 @@
 package com.github.charlyb01.music_control.client;
 
 import com.github.charlyb01.music_control.Utils;
-import com.github.charlyb01.music_control.imixin.GameOptionsAccess;
 import com.github.charlyb01.music_control.config.ModConfig;
 import com.github.charlyb01.music_control.gui.MusicControlGUI;
 import com.github.charlyb01.music_control.gui.MusicControlScreen;
+import com.github.charlyb01.music_control.imixin.GameOptionsAccess;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.option.KeyBinding;
@@ -57,7 +57,7 @@ public class MusicKeyBinding {
         loopMusic = KeyBindingHelper.registerKeyBinding(new KeyBinding(
                 "key.music_control.loop",
                 InputUtil.Type.KEYSYM,
-                InputUtil.UNKNOWN_KEY.getCode(),
+                GLFW.GLFW_KEY_UNKNOWN,
                 mainCategory
         ));
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,8 +28,10 @@
   ],
   "accessWidener": "music_control.accesswidener",
   "depends": {
-    "fabricloader": ">=0.17.0",
-    "fabric-api": ">=0.114.3"
+    "fabricloader": ">=0.17.3",
+    "fabric-api": ">=0.138.3+1.21.10",
+    "minecraft": ">=1.21.10",
+    "java": ">=21"
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
Adding full compatibility with Minecraft 1.21.10.

- Updated the build to target Minecraft 1.21.10 with newer Fabric Loom tooling and dependencies.
- Adjusted keybinding registration to use the current Fabric input APIs.
- Raised minimum dependency versions in `fabric.mod.json` to match the updated platform requirements.

I tested/built it on my laptop, but please test/build it too.

_Resolves issue #89_